### PR TITLE
UAT fixes - Batch 1

### DIFF
--- a/src/Classes/derivedSettingsClass.ts
+++ b/src/Classes/derivedSettingsClass.ts
@@ -1,0 +1,27 @@
+import {defaultSettingsType} from "./settingsClass"
+
+export default class derivedSettingsClass {
+  multiplier: number
+  percentLabels: boolean
+
+  update(inputSettings: defaultSettingsType) {
+    const chartType: string = inputSettings.spc.chart_type;
+    const pChartType: boolean = ["p", "pp"].includes(chartType);
+    const percentSettingString: string = inputSettings.spc.perc_labels;
+    let multiplier: number = inputSettings.spc.multiplier;
+    let percentLabels: boolean;
+
+    if (pChartType) {
+      multiplier = multiplier === 1 ? 100 : multiplier
+    }
+
+    if (percentSettingString === "Automatic") {
+      percentLabels = pChartType && multiplier === 100;
+    } else {
+      percentLabels = percentSettingString === "Yes";
+    }
+
+    this.multiplier = multiplier
+    this.percentLabels = percentLabels
+  }
+}

--- a/src/Classes/index.ts
+++ b/src/Classes/index.ts
@@ -2,3 +2,4 @@ export { default as plotPropertiesClass, type axisProperties } from "./plotPrope
 export { default as settingsClass, type defaultSettingsType, type defaultSettingsKey, type settingsScalarTypes } from "./settingsClass"
 export { default as viewModelClass, type plotData, type lineData, type controlLimitsObject, type controlLimitsArgs, type outliersObject } from "./viewModelClass"
 export { default as validationErrorClass } from "./validationErrorClass"
+export { default as derivedSettingsClass } from "./derivedSettingsClass"

--- a/src/Classes/settingsClass.ts
+++ b/src/Classes/settingsClass.ts
@@ -8,6 +8,7 @@ type VisualObjectInstanceContainer = powerbi.default.VisualObjectInstanceContain
 import { dataViewWildcard } from "powerbi-visuals-utils-dataviewutils";
 import { extractConditionalFormatting } from "../Functions";
 import { default as defaultSettings, settingsPaneGroupings } from "../defaultSettings";
+import derivedSettingsClass from "./derivedSettingsClass";
 
 export type defaultSettingsType = typeof defaultSettings;
 export type defaultSettingsKey = keyof defaultSettingsType;
@@ -22,6 +23,7 @@ export type settingsScalarTypes = number | string | boolean;
  */
 export default class settingsClass {
   settings: defaultSettingsType;
+  derivedSettings: derivedSettingsClass
 
   /**
    * Function to read the values from the settings pane and update the
@@ -43,6 +45,8 @@ export default class settingsClass {
         this.settings[settingGroup][settingName] = condFormatting ? condFormatting[settingName] : defaultSettings[settingGroup][settingName]
       })
     })
+
+    this.derivedSettings.update(this.settings)
   }
 
   /**
@@ -86,5 +90,6 @@ export default class settingsClass {
 
   constructor() {
     this.settings = JSON.parse(JSON.stringify(defaultSettings));
+    this.derivedSettings = new derivedSettingsClass();
   }
 }

--- a/src/Classes/viewModelClass.ts
+++ b/src/Classes/viewModelClass.ts
@@ -94,13 +94,14 @@ export default class viewModelClass {
       this.initialiseGroupedLines();
     }
 
-    this.plotProperties.update({
-      options: options,
-      plotPoints: this.plotPoints,
-      controlLimits: this.controlLimits,
-      inputData: this.inputData,
-      inputSettings: this.inputSettings.settings
-    })
+    this.plotProperties.update(
+      options,
+      this.plotPoints,
+      this.controlLimits,
+      this.inputData,
+      this.inputSettings.settings,
+      this.inputSettings.derivedSettings
+    )
     this.firstRun = false;
   }
 
@@ -180,7 +181,7 @@ export default class viewModelClass {
                                     this.inputData.limitInputArgs.keys[i].id)
                       .createSelectionId(),
         highlighted: this.inputData.highlights?.at(index) != null,
-        tooltip: buildTooltip(i, this.controlLimits, this.outliers, this.inputData, this.inputSettings.settings)
+        tooltip: buildTooltip(i, this.controlLimits, this.outliers, this.inputData, this.inputSettings.settings, this.inputSettings.derivedSettings)
       })
       this.tickLabels.push({x: index, label: this.controlLimits.keys[i].label});
     }
@@ -218,7 +219,7 @@ export default class viewModelClass {
 
   scaleAndTruncateLimits(): void {
     // Scale limits using provided multiplier
-    const multiplier: number = this.inputSettings.settings.spc.multiplier;
+    const multiplier: number = this.inputSettings.derivedSettings.multiplier;
 
     ["values", "targets", "alt_targets", "ll99", "ll95", "ul95", "ul99"].forEach(limit => {
       this.controlLimits[limit] = multiply(this.controlLimits[limit], multiplier)

--- a/src/Classes/viewModelClass.ts
+++ b/src/Classes/viewModelClass.ts
@@ -241,13 +241,11 @@ export default class viewModelClass {
   flagOutliers() {
     const process_flag_type: string = this.inputSettings.settings.outliers.process_flag_type;
     const improvement_direction: string = this.inputSettings.settings.outliers.improvement_direction;
-    if (!(this.outliers)) {
-      this.outliers = {
-        astpoint: rep("none", this.inputData.limitInputArgs.keys.length),
-        two_in_three: rep("none", this.inputData.limitInputArgs.keys.length),
-        trend: rep("none", this.inputData.limitInputArgs.keys.length),
-        shift: rep("none", this.inputData.limitInputArgs.keys.length)
-      }
+    this.outliers = {
+      astpoint: rep("none", this.inputData.limitInputArgs.keys.length),
+      two_in_three: rep("none", this.inputData.limitInputArgs.keys.length),
+      trend: rep("none", this.inputData.limitInputArgs.keys.length),
+      shift: rep("none", this.inputData.limitInputArgs.keys.length)
     }
     if (this.inputSettings.settings.spc.chart_type !== "run") {
       if (this.inputSettings.settings.outliers.astronomical) {

--- a/src/D3 Plotting Functions/drawDots.ts
+++ b/src/D3 Plotting Functions/drawDots.ts
@@ -14,9 +14,11 @@ export default function drawDots(selection: svgBaseType, visualObj: Visual) {
       .attr("cx", (d: plotData) => visualObj.viewModel.plotProperties.xScale(d.x))
       .attr("r", (d: plotData) => d.aesthetics.size)
       .style("fill", (d: plotData) => {
-        const lower: number = visualObj.viewModel.plotProperties.yAxis.lower;
-        const upper: number = visualObj.viewModel.plotProperties.yAxis.upper;
-        return between(d.value, lower, upper) ? d.aesthetics.colour : "#FFFFFF";
+        const ylower: number = visualObj.viewModel.plotProperties.yAxis.lower;
+        const yupper: number = visualObj.viewModel.plotProperties.yAxis.upper;
+        const xlower: number = visualObj.viewModel.plotProperties.xAxis.lower;
+        const xupper: number = visualObj.viewModel.plotProperties.xAxis.upper;
+        return (between(d.value, ylower, yupper) && between(d.x, xlower, xupper)) ? d.aesthetics.colour : "#FFFFFF";
       })
       .on("click", (event, d: plotData) => {
           if (visualObj.viewModel.inputSettings.settings.spc.split_on_click) {

--- a/src/D3 Plotting Functions/drawLines.ts
+++ b/src/D3 Plotting Functions/drawLines.ts
@@ -10,12 +10,18 @@ export default function drawLines(selection: svgBaseType, visualObj: Visual) {
       .data(visualObj.viewModel.groupedLines)
       .join("path")
       .attr("d", d => {
-        const lower: number = visualObj.viewModel.plotProperties.yAxis.lower;
-        const upper: number = visualObj.viewModel.plotProperties.yAxis.upper;
+        const ylower: number = visualObj.viewModel.plotProperties.yAxis.lower;
+        const yupper: number = visualObj.viewModel.plotProperties.yAxis.upper;
+        const xlower: number = visualObj.viewModel.plotProperties.xAxis.lower;
+        const xupper: number = visualObj.viewModel.plotProperties.xAxis.upper;
         return d3.line<lineData>()
                   .x(d => visualObj.viewModel.plotProperties.xScale(d.x))
                   .y(d => visualObj.viewModel.plotProperties.yScale(d.line_value))
-                  .defined(d => d.line_value !== null && between(d.line_value, lower, upper))(d[1])
+                  .defined(d => {
+                    return d.line_value !== null
+                      && between(d.line_value, ylower, yupper)
+                      && between(d.x, xlower, xupper)
+                  })(d[1])
       })
       .attr("fill", "none")
       .attr("stroke", d => getAesthetic(d[0], "lines", "colour", visualObj.viewModel.inputSettings.settings))

--- a/src/D3 Plotting Functions/drawYAxis.ts
+++ b/src/D3 Plotting Functions/drawYAxis.ts
@@ -9,7 +9,6 @@ export default function drawYAxis(selection: svgBaseType, visualObj: Visual, ref
   const yAxis: d3.Axis<d3.NumberValue> = d3.axisLeft(visualObj.viewModel.plotProperties.yScale);
   const yaxis_sig_figs: number = visualObj.viewModel.inputSettings.settings.y_axis.ylimit_sig_figs;
   const sig_figs: number = yaxis_sig_figs === null ? visualObj.viewModel.inputSettings.settings.spc.sig_figs : yaxis_sig_figs;
-  const multiplier: number = visualObj.viewModel.inputSettings.settings.spc.multiplier;
   const displayPlot: boolean = visualObj.viewModel.plotProperties.displayPlot;
 
   if (yAxisProperties.ticks) {
@@ -19,8 +18,8 @@ export default function drawYAxis(selection: svgBaseType, visualObj: Visual, ref
     if (visualObj.viewModel.inputData) {
       yAxis.tickFormat(
         (d: number) => {
-          return visualObj.viewModel.inputData.percentLabels
-            ? (d * (multiplier === 100 ? 1 : (multiplier === 1 ? 100 : multiplier))).toFixed(sig_figs) + "%"
+          return visualObj.viewModel.inputSettings.derivedSettings.percentLabels
+            ? d.toFixed(sig_figs) + "%"
             : d.toFixed(sig_figs);
         }
       );

--- a/src/Functions/buildTooltip.ts
+++ b/src/Functions/buildTooltip.ts
@@ -40,6 +40,8 @@ export default function buildTooltip(index: number,
   const trend: string = outliers.trend[index];
   const shift: string = outliers.shift[index];
   const two_in_three: string = outliers.two_in_three[index];
+  let multiplier: number = inputSettings.spc.multiplier;
+  multiplier = prop_labels ? (multiplier === 100 ? 1 : (multiplier === 1 ? 100 : multiplier)) : 1;
   const suffix: string = prop_labels ? "%" : "";
   const intNumDen: boolean = integerParams.includes(chart_type);
 
@@ -51,7 +53,7 @@ export default function buildTooltip(index: number,
   });
   tooltip.push({
     displayName: valueNames[chart_type],
-    value: (value).toFixed(sig_figs) + suffix
+    value: (value * multiplier).toFixed(sig_figs) + suffix
   })
   if(numerator || !(numerator === null || numerator === undefined)) {
     tooltip.push({
@@ -68,17 +70,17 @@ export default function buildTooltip(index: number,
   if (chart_type !== "run") {
     tooltip.push({
       displayName: "Upper 99% Limit",
-      value: (limits.ul99).toFixed(sig_figs) + suffix
+      value: (limits.ul99 * multiplier).toFixed(sig_figs) + suffix
     })
   }
   tooltip.push({
     displayName: "Centerline",
-    value: (target).toFixed(sig_figs) + suffix
+    value: (target * multiplier).toFixed(sig_figs) + suffix
   })
   if (chart_type !== "run") {
     tooltip.push({
       displayName: "Lower 99% Limit",
-      value: (limits.ll99).toFixed(sig_figs) + suffix
+      value: (limits.ll99 * multiplier).toFixed(sig_figs) + suffix
     })
   }
 

--- a/src/Functions/buildTooltip.ts
+++ b/src/Functions/buildTooltip.ts
@@ -1,6 +1,6 @@
 import type powerbi from "powerbi-visuals-api";
 type VisualTooltipDataItem = powerbi.extensibility.VisualTooltipDataItem;
-import type { controlLimitsObject, defaultSettingsType, outliersObject } from "../Classes";
+import type { controlLimitsObject, defaultSettingsType, derivedSettingsClass, outliersObject } from "../Classes";
 import type { dataObject } from "./extractInputData";
 
 const valueNames: Record<string, string> = {
@@ -24,25 +24,23 @@ export default function buildTooltip(index: number,
                                       controlLimits: controlLimitsObject,
                                       outliers: outliersObject,
                                       inputData: dataObject,
-                                      inputSettings: defaultSettingsType): VisualTooltipDataItem[] {
+                                      inputSettings: defaultSettingsType,
+                                      derivedSettings: derivedSettingsClass): VisualTooltipDataItem[] {
   const chart_type: string = inputSettings.spc.chart_type;
   const date: string = controlLimits.keys[index].label;
   const value: number = controlLimits.values[index];
-  const numerator: number = controlLimits.numerators ? controlLimits.numerators[index] : null;
-  const denominator: number = controlLimits.denominators ? controlLimits.denominators[index] : null;
+  const numerator: number = controlLimits.numerators?.[index];
+  const denominator: number = controlLimits.denominators?.[index];
   const target: number = controlLimits.targets[index];
   const limits = {
-      ll99: controlLimits.ll99 ? controlLimits.ll99[index] : null,
-      ul99: controlLimits.ll99 ? controlLimits.ul99[index] : null
-    };
-  const prop_labels: boolean = inputData.percentLabels;
+    ll99: controlLimits?.ll99?.[index],
+    ul99: controlLimits?.ul99?.[index]
+  };
   const astpoint: string = outliers.astpoint[index];
   const trend: string = outliers.trend[index];
   const shift: string = outliers.shift[index];
   const two_in_three: string = outliers.two_in_three[index];
-  let multiplier: number = inputSettings.spc.multiplier;
-  multiplier = prop_labels ? (multiplier === 100 ? 1 : (multiplier === 1 ? 100 : multiplier)) : 1;
-  const suffix: string = prop_labels ? "%" : "";
+  const suffix: string = derivedSettings.percentLabels ? "%" : "";
   const intNumDen: boolean = integerParams.includes(chart_type);
 
   const sig_figs: number = inputSettings.spc.sig_figs;
@@ -53,7 +51,7 @@ export default function buildTooltip(index: number,
   });
   tooltip.push({
     displayName: valueNames[chart_type],
-    value: (value * multiplier).toFixed(sig_figs) + suffix
+    value: (value).toFixed(sig_figs) + suffix
   })
   if(numerator || !(numerator === null || numerator === undefined)) {
     tooltip.push({
@@ -70,17 +68,17 @@ export default function buildTooltip(index: number,
   if (chart_type !== "run") {
     tooltip.push({
       displayName: "Upper 99% Limit",
-      value: (limits.ul99 * multiplier).toFixed(sig_figs) + suffix
+      value: (limits.ul99).toFixed(sig_figs) + suffix
     })
   }
   tooltip.push({
     displayName: "Centerline",
-    value: (target * multiplier).toFixed(sig_figs) + suffix
+    value: (target).toFixed(sig_figs) + suffix
   })
   if (chart_type !== "run") {
     tooltip.push({
       displayName: "Lower 99% Limit",
-      value: (limits.ll99 * multiplier).toFixed(sig_figs) + suffix
+      value: (limits.ll99).toFixed(sig_figs) + suffix
     })
   }
 

--- a/src/Functions/extractInputData.ts
+++ b/src/Functions/extractInputData.ts
@@ -10,7 +10,6 @@ export type dataObject = {
   limitInputArgs: controlLimitsArgs;
   highlights: PrimitiveValue[];
   anyHighlights: boolean;
-  percentLabels: boolean;
   categories: DataViewCategoryColumn;
   scatter_formatting: defaultSettingsType["scatter"][];
   tooltips: VisualTooltipDataItem[][];
@@ -43,13 +42,6 @@ export default function extractInputData(inputView: DataViewCategorical, inputSe
     }
   }
 
-  let percent_labels: boolean;
-  if (inputSettings.spc.perc_labels === "Automatic") {
-    percent_labels = ["p", "pp"].includes(inputSettings.spc.chart_type) && (inputSettings.spc.multiplier === 1 || inputSettings.spc.multiplier === 100);
-  } else {
-    percent_labels = inputSettings.spc.perc_labels === "Yes";
-  }
-
   return {
     limitInputArgs: {
       keys: valid_keys,
@@ -62,7 +54,6 @@ export default function extractInputData(inputView: DataViewCategorical, inputSe
     highlights: extractValues(highlights, valid_ids),
     anyHighlights: highlights != null,
     categories: inputView.categories[0],
-    percentLabels: percent_labels,
     scatter_formatting: extractValues(scatter_cond, valid_ids),
     warningMessage: removalMessages.length >0 ? removalMessages.join("\n") : ""
   }


### PR DESCRIPTION
Fixes:

- Plotting doesn't respect x-axis limits
- P-charts need multiplier of 100 for % tooltips
- Outlier highlighting can't be turned off

Also centralises handling of settings derived from input settings (whether `%` should be displayed, multiplier of both 1 and 100 should be handled as 100 for p-charts). Needed for consistent handling of axis limit and alt target values with multipliers