### PR TITLE
Add Built Visual to PR action artifacts

### DIFF
--- a/.github/workflows/build_visual.yml
+++ b/.github/workflows/build_visual.yml
@@ -38,3 +38,10 @@ jobs:
     - name: Test if package can be built
       run: |
         pbiviz package
+
+    - name: Attach built visual
+      if: success()
+      uses: actions/upload-artifact@v4
+      with:
+        name: powerbi-visual-${{ github.sha }}
+        path: dist/*.pbiviz


### PR DESCRIPTION
This PR adds the built visual as an artifact to the PR job to allow easy validation/checking/testing of PRs without having to spin anything else up.

Could also add it to the general workflow runs or a workflow_dispatch trigger to allow on-demand generation if required, but given the merge strategy you're using this should probably do it.

Artifacts expire after 90 days by default.

The artifact zip will have the github SHA as part of the filename, however the visual itself will remain versioned as normal.

You can see the completed action with artifact [here](https://github.com/shaunes-rmh/PowerBI-SPC/actions/runs/10445602069).