### PR TITLE
Fix 7 production bugs in validation, u-chart constraint, and rendering null-safety

### DIFF
--- a/src/Classes/derivedSettingsClass.ts
+++ b/src/Classes/derivedSettingsClass.ts
@@ -60,7 +60,7 @@ export default class derivedSettingsClass {
       needs_denominator: ["p", "pp", "u", "up", "xbar", "s"].includes(chartType),
       denominator_optional: ["i", "i_m", "i_mm", "run", "mr"].includes(chartType),
       numerator_non_negative: ["p", "pp", "u", "up", "s", "c", "g", "t"].includes(chartType),
-      numerator_leq_denominator: ["p", "pp", "u", "up"].includes(chartType),
+      numerator_leq_denominator: ["p", "pp"].includes(chartType),
       has_control_limits: !(["run"].includes(chartType)),
       needs_sd: ["xbar"].includes(chartType),
       integer_num_den: ["c", "p", "pp"].includes(chartType),

--- a/src/Classes/viewModelClass.ts
+++ b/src/Classes/viewModelClass.ts
@@ -35,7 +35,7 @@ export type viewModelValidationT = {
 
 export type lineData = {
   x: number;
-  line_value: number;
+  line_value: number | null;
   group: string;
   aesthetics: defaultSettingsType["lines"];
 }
@@ -93,10 +93,10 @@ export type plotData = {
   label: {
     text_value: string,
     aesthetics: defaultSettingsType["labels"],
-    angle: number,
-    distance: number,
-    line_offset: number,
-    marker_offset: number
+    angle: number | null,
+    distance: number | null,
+    line_offset: number | null,
+    marker_offset: number | null
   };
 }
 
@@ -417,6 +417,10 @@ export default class viewModelClass {
       if (key === "keys") {
         continue;
       }
+      // TODO: This introduces null into number[] arrays (controlLimitsObject types declare number[]).
+      // The type definitions should be updated to (number | null)[] for all limit arrays,
+      // but this affects hundreds of consumers across limit calculations, outlier flagging,
+      // and rendering. Needs its own analysis pass to update safely.
       controlLimits[key] = controlLimits[key]?.map(d => isNaN(d) ? null : d);
     }
 

--- a/src/D3 Plotting Functions/drawLineLabels.ts
+++ b/src/D3 Plotting Functions/drawLineLabels.ts
@@ -81,8 +81,9 @@ export default function drawLineLabels(selection: svgBaseType, visualObj: Visual
     .join("text")
     .text((d: lineLabelType) => {
       const lineGroup: [string, lineData[]] = visualObj.viewModel.groupedLines[d.limit];
-      return lineSettings[`plot_label_show_${lineNameMap[lineGroup[0]]}`]
-              ? lineSettings[`plot_label_prefix_${lineNameMap[lineGroup[0]]}`] + formatValue(lineGroup[1][d.index].line_value, "value")
+      const lineValue = lineGroup[1][d.index].line_value;
+      return lineSettings[`plot_label_show_${lineNameMap[lineGroup[0]]}`] && lineValue !== null
+              ? lineSettings[`plot_label_prefix_${lineNameMap[lineGroup[0]]}`] + formatValue(lineValue, "value")
               : "";
     })
     .attr("x", (d: lineLabelType) => {
@@ -91,7 +92,8 @@ export default function drawLineLabels(selection: svgBaseType, visualObj: Visual
     })
     .attr("y", (d: lineLabelType) => {
       const lineGroup: [string, lineData[]] = visualObj.viewModel.groupedLines[d.limit];
-      return visualObj.plotProperties.yScale(lineGroup[1][d.index].line_value)
+      const lineValue = lineGroup[1][d.index].line_value;
+      return lineValue !== null ? visualObj.plotProperties.yScale(lineValue) : 0;
     })
     .attr("fill", (d: lineLabelType) => {
       const lineGroup: [string, lineData[]] = visualObj.viewModel.groupedLines[d.limit];

--- a/src/D3 Plotting Functions/drawLines.ts
+++ b/src/D3 Plotting Functions/drawLines.ts
@@ -31,8 +31,8 @@ export default function drawLines(selection: svgBaseType, visualObj: Visual) {
           const currPoint: lineData = currLineData[i];
 
           xValues[i] = visualObj.plotProperties.xScale(currPoint.x);
-          yValues[i] = visualObj.plotProperties.yScale(currPoint.line_value);
           yValidStatus[i] = !isNullOrUndefined(currPoint.line_value) && between(currPoint.line_value, ylower, yupper);
+          yValues[i] = yValidStatus[i] ? visualObj.plotProperties.yScale(currPoint.line_value) : NaN;
           anyValid = anyValid || yValidStatus[i];
         }
 

--- a/src/Functions/validateDataView.ts
+++ b/src/Functions/validateDataView.ts
@@ -8,7 +8,7 @@ export default function validateDataView(inputDV: powerbi.DataView[], inputSetti
   if (isNullOrUndefined(inputDV?.[0]) || (inputDV?.[0]?.categorical?.categories?.[0]?.identity?.length === 0)) {
     return ""; //"No data present!";
   }
-  if (isNullOrUndefined(inputDV[0]?.categorical?.categories) || isNullOrUndefined(inputDV[0]?.categorical?.categories.some(d => d.source?.roles?.key))) {
+  if (isNullOrUndefined(inputDV[0]?.categorical?.categories) || !inputDV[0]?.categorical?.categories.some(d => d.source?.roles?.key)) {
     return ""; //"No grouping/ID variable passed!";
   }
 
@@ -21,25 +21,22 @@ export default function validateDataView(inputDV: powerbi.DataView[], inputSetti
     return "No Numerators passed!";
   }
 
-  let needs_denominator: boolean;
-  let needs_sd: boolean;
-  let chart_type: string;
+  let needs_denominator = false;
+  let needs_sd = false;
+  let denom_chart_type = "";
+  let sd_chart_type = "";
 
-  if (inputSettingsClass?.derivedSettings.length > 0) {
-    inputSettingsClass?.derivedSettings.forEach((d) => {
+  if (inputSettingsClass?.derivedSettings?.length > 0) {
+    for (const d of inputSettingsClass.derivedSettings) {
       if (d.chart_type_props.needs_denominator) {
-        chart_type = d.chart_type_props.name;
+        denom_chart_type = denom_chart_type || d.chart_type_props.name;
         needs_denominator = true;
       }
       if (d.chart_type_props.needs_sd) {
-        chart_type = d.chart_type_props.name;
+        sd_chart_type = sd_chart_type || d.chart_type_props.name;
         needs_sd = true;
       }
-    });
-  } else {
-    chart_type = inputSettingsClass.settings[0].spc.chart_type;
-    needs_denominator = inputSettingsClass.derivedSettings[0].chart_type_props.needs_denominator;
-    needs_sd = inputSettingsClass.derivedSettings[0].chart_type_props.needs_sd;
+    }
   }
 
   if (needs_denominator) {
@@ -49,7 +46,7 @@ export default function validateDataView(inputDV: powerbi.DataView[], inputSetti
                      ?.some(d => d.source?.roles?.denominators);
 
     if (!denominatorsPresent) {
-      return `Chart type '${chart_type}' requires denominators!`;
+      return `Chart type '${denom_chart_type}' requires denominators!`;
     }
   }
 
@@ -60,7 +57,7 @@ export default function validateDataView(inputDV: powerbi.DataView[], inputSetti
                      ?.some(d => d.source?.roles?.xbar_sds);
 
     if (!xbarSDPresent) {
-      return `Chart type '${chart_type}' requires SDs!`;
+      return `Chart type '${sd_chart_type}' requires SDs!`;
     }
   }
 

--- a/src/Functions/validateInputData.ts
+++ b/src/Functions/validateInputData.ts
@@ -3,161 +3,140 @@ import isNullOrUndefined from "./isNullOrUndefined";
 
 export type ValidationT = { status: number, messages: string[], error?: string };
 
-const enum ValidationFailTypes {
+enum ValidationFailTypes {
   Valid = 0,
   DateMissing = 2,
   NumeratorMissing = 3,
   NumeratorNegative = 4,
+  NumeratorNaN = 10,
   DenominatorMissing = 5,
   DenominatorNegative = 6,
   DenominatorLessThanNumerator = 7,
+  DenominatorNaN = 11,
+  DenominatorZero = 13,
   SDMissing = 8,
   SDNegative = 9,
-  NumeratorNaN = 10,
-  DenominatorNaN = 11,
   SDNaN = 12,
-  DenominatorZero = 13
 }
 
-function validateInputDataImpl(key: string,
-                              numerator: number,
-                              denominator: number,
-                              xbar_sd: number,
-                              chart_type_props: derivedSettingsClass["chart_type_props"],
-                              check_denom: boolean): { message: string, type: ValidationFailTypes }  {
+// Short alias for the enum — used as both a type and a value throughout this file
+type V = ValidationFailTypes;
+const V = ValidationFailTypes;
 
-  const rtn = { message: "", type: ValidationFailTypes.Valid };
-  if (isNullOrUndefined(key)) {
-    rtn.message = "Date missing";
-    rtn.type = ValidationFailTypes.DateMissing;
-  } else if (isNullOrUndefined(numerator)) {
-    rtn.message = "Numerator missing";
-    rtn.type = ValidationFailTypes.NumeratorMissing;
-  } else if (!isFinite(numerator)) {
-    rtn.message = "Numerator is not a number";
-    rtn.type = ValidationFailTypes.NumeratorNaN;
-  } else if (chart_type_props.numerator_non_negative && numerator < 0) {
-    rtn.message = "Numerator negative";
-    rtn.type = ValidationFailTypes.NumeratorNegative;
-  } else if (check_denom && isNullOrUndefined(denominator)) {
-    rtn.message = "Denominator missing";
-    rtn.type = ValidationFailTypes.DenominatorMissing;
-  } else if (check_denom && !isFinite(denominator)) {
-    rtn.message = "Denominator is not a number";
-    rtn.type = ValidationFailTypes.DenominatorNaN;
-  } else if (check_denom && denominator < 0) {
-    rtn.message = "Denominator negative";
-    rtn.type = ValidationFailTypes.DenominatorNegative;
-  } else if (check_denom && denominator === 0) {
-    rtn.message = "Denominator is zero";
-    rtn.type = ValidationFailTypes.DenominatorZero;
-  } else if (check_denom && chart_type_props.numerator_leq_denominator && denominator < numerator) {
-    rtn.message = "Denominator < numerator";
-    rtn.type = ValidationFailTypes.DenominatorLessThanNumerator;
-  } else if (chart_type_props.needs_sd && isNullOrUndefined(xbar_sd)) {
-    rtn.message = "SD missing";
-    rtn.type = ValidationFailTypes.SDMissing;
-  } else if (chart_type_props.needs_sd && !isFinite(xbar_sd)) {
-    rtn.message = "SD is not a number";
-    rtn.type = ValidationFailTypes.SDNaN;
-  } else if (chart_type_props.needs_sd && xbar_sd < 0) {
-    rtn.message = "SD negative";
-    rtn.type = ValidationFailTypes.SDNegative;
-  }
-  return rtn;
+// row: per-observation message (shown in removal warnings)
+// all: aggregate error when every observation fails with the same type
+const validationMessages: Record<V, { row: string; all: string }> = {
+  [V.Valid]:                        { row: "",                            all: "" },
+  [V.DateMissing]:                  { row: "Date missing",                all: "All dates/IDs are missing or null!" },
+  [V.NumeratorMissing]:             { row: "Numerator missing",           all: "All numerators are missing or null!" },
+  [V.NumeratorNaN]:                 { row: "Numerator is not a number",   all: "All numerators are not numbers!" },
+  [V.NumeratorNegative]:            { row: "Numerator negative",          all: "All numerators are negative!" },
+  [V.DenominatorMissing]:           { row: "Denominator missing",         all: "All denominators missing or null!" },
+  [V.DenominatorNaN]:               { row: "Denominator is not a number", all: "All denominators are not numbers!" },
+  [V.DenominatorNegative]:          { row: "Denominator negative",        all: "All denominators are negative!" },
+  [V.DenominatorZero]:              { row: "Denominator is zero",         all: "All denominators are zero!" },
+  [V.DenominatorLessThanNumerator]: { row: "Denominator < numerator",     all: "All denominators are smaller than numerators!" },
+  [V.SDMissing]:                    { row: "SD missing",                  all: "All SDs missing or null!" },
+  [V.SDNaN]:                        { row: "SD is not a number",          all: "All SDs are not numbers!" },
+  [V.SDNegative]:                   { row: "SD negative",                 all: "All SDs are negative!" },
+};
+
+// Validates a single data row. Guard clause order matters: null/undefined checks
+// must precede Number.isFinite checks (Number.isFinite(null) === false would
+// otherwise report "not a number" instead of "missing").
+function validateInputDataImpl(
+  key: string,
+  numerator: number,
+  denominator: number,
+  xbar_sd: number,
+  chart_type_props: derivedSettingsClass["chart_type_props"],
+  check_denom: boolean
+): V {
+  if (isNullOrUndefined(key))
+    return V.DateMissing;
+
+  if (isNullOrUndefined(numerator))
+    return V.NumeratorMissing;
+  if (!Number.isFinite(numerator))
+    return V.NumeratorNaN;
+  if (chart_type_props.numerator_non_negative && numerator < 0)
+    return V.NumeratorNegative;
+
+  if (check_denom && isNullOrUndefined(denominator))
+    return V.DenominatorMissing;
+  if (check_denom && !Number.isFinite(denominator))
+    return V.DenominatorNaN;
+  if (check_denom && denominator < 0)
+    return V.DenominatorNegative;
+  if (check_denom && denominator === 0)
+    return V.DenominatorZero;
+  if (check_denom && chart_type_props.numerator_leq_denominator && denominator < numerator)
+    return V.DenominatorLessThanNumerator;
+
+  if (chart_type_props.needs_sd && isNullOrUndefined(xbar_sd))
+    return V.SDMissing;
+  if (chart_type_props.needs_sd && !Number.isFinite(xbar_sd))
+    return V.SDNaN;
+  if (chart_type_props.needs_sd && xbar_sd < 0)
+    return V.SDNegative;
+
+  return V.Valid;
 }
 
-// ESLint errors due to number of lines in function, but would reduce readability to separate further
-
-export default function validateInputData(keys: string[],
-                                          numerators: number[],
-                                          denominators: number[],
-                                          xbar_sds: number[],
-                                          chart_type_props: derivedSettingsClass["chart_type_props"],
-                                          idxs: number[]): { status: number, messages: string[], error?: string } {
-  let allSameType: boolean = false;
-  let messages: string[] = new Array<string>();
-  let all_status: ValidationFailTypes[] = new Array<ValidationFailTypes>();
-  const check_denom = chart_type_props.needs_denominator
-                      || (chart_type_props.denominator_optional && !isNullOrUndefined(denominators) && denominators.length > 0);
+export default function validateInputData(
+  keys: string[],
+  numerators: number[],
+  denominators: number[],
+  xbar_sds: number[],
+  chart_type_props: derivedSettingsClass["chart_type_props"],
+  idxs: number[]
+): ValidationT {
   const n: number = idxs.length;
+  if (n === 0) {
+    return { status: 1, messages: [], error: "No valid data found!" };
+  }
+
+  const messages: string[] = [];
+  const all_status: V[] = [];
+  // needs_denominator (p, pp, u, etc.): always validate denominator
+  const denom_required: boolean = chart_type_props.needs_denominator;
+  // denominator_optional (i, mr, run, etc.): only validate rows where a denominator
+  // value was actually provided. Without per-row checking, null rows on optional
+  // charts would incorrectly fail with "Denominator missing".
+  const denom_optional: boolean = chart_type_props.denominator_optional
+                                  && !isNullOrUndefined(denominators)
+                                  && denominators.length > 0;
+
   for (let i = 0; i < n; i++) {
     const idx = idxs[i];
-    const validation = validateInputDataImpl(keys[idx], numerators?.[idx], denominators?.[idx], xbar_sds?.[idx], chart_type_props,  check_denom);
-    messages.push(validation.message);
-    all_status.push(validation.type);
+    const check_denom = denom_required || (denom_optional && !isNullOrUndefined(denominators?.[idx]));
+    const failType = validateInputDataImpl(
+      keys[idx], numerators?.[idx], denominators?.[idx], xbar_sds?.[idx],
+      chart_type_props, check_denom
+    );
+    messages.push(validationMessages[failType].row);
+    all_status.push(failType);
   }
 
-  let allSameTypeSet = new Set(all_status);
-  allSameType = allSameTypeSet.size === 1;
-  let commonType = Array.from(allSameTypeSet)[0];
+  // Determine overall status: if any row is valid, status=0 (partial data is usable).
+  // If all rows failed: use a specific error when all failed for the same reason,
+  // otherwise use a generic message.
+  const failureTypes = new Set(all_status);
+  const hasValidData = failureTypes.has(V.Valid);
 
-  let validationRtn: ValidationT = {
-    status: (allSameType && commonType !== ValidationFailTypes.Valid) ? 1 : 0,
-    messages: messages
+  const validationRtn: ValidationT = {
+    status: hasValidData ? 0 : 1,
+    messages,
   };
 
-  // If all data has failed, but for different reasons, return a generic error
-  if (validationRtn.status === 0) {
-    const allInvalid: boolean = all_status.every(d => d !== ValidationFailTypes.Valid);
-    if (allInvalid) {
-      validationRtn.status = 1; // All data invalid
+  if (!hasValidData) {
+    if (failureTypes.size === 1) {
+      const commonType = failureTypes.values().next().value as V;
+      validationRtn.error = validationMessages[commonType].all;
+    } else {
       validationRtn.error = "No valid data found!";
-      return validationRtn;
     }
   }
 
-  if (allSameType && commonType !== ValidationFailTypes.Valid) {
-    switch(commonType) {
-      case ValidationFailTypes.DateMissing: {
-        validationRtn.error = "All dates/IDs are missing or null!"
-        break;
-      }
-      case ValidationFailTypes.NumeratorMissing: {
-        validationRtn.error = "All numerators are missing or null!"
-        break;
-      }
-      case ValidationFailTypes.NumeratorNaN: {
-        validationRtn.error = "All numerators are not numbers!"
-        break;
-      }
-      case ValidationFailTypes.NumeratorNegative: {
-        validationRtn.error = "All numerators are negative!"
-        break;
-      }
-      case ValidationFailTypes.DenominatorMissing: {
-        validationRtn.error = "All denominators missing or null!"
-        break;
-      }
-      case ValidationFailTypes.DenominatorNaN: {
-        validationRtn.error = "All denominators are not numbers!"
-        break;
-      }
-      case ValidationFailTypes.DenominatorNegative: {
-        validationRtn.error = "All denominators are negative!"
-        break;
-      }
-      case ValidationFailTypes.DenominatorZero: {
-        validationRtn.error = "All denominators are zero!";
-        break;
-      }
-      case ValidationFailTypes.DenominatorLessThanNumerator: {
-        validationRtn.error = "All denominators are smaller than numerators!";
-        break;
-      }
-      case ValidationFailTypes.SDMissing: {
-        validationRtn.error = "All SDs missing or null!";
-        break;
-      }
-      case ValidationFailTypes.SDNaN: {
-        validationRtn.error = "All SDs are not numbers!";
-        break;
-      }
-      case ValidationFailTypes.SDNegative: {
-        validationRtn.error = "All SDs are negative!";
-        break;
-      }
-    }
-  }
   return validationRtn;
 }

--- a/src/Functions/validateInputData.ts
+++ b/src/Functions/validateInputData.ts
@@ -5,7 +5,6 @@ export type ValidationT = { status: number, messages: string[], error?: string }
 
 const enum ValidationFailTypes {
   Valid = 0,
-  GroupingMissing = 1,
   DateMissing = 2,
   NumeratorMissing = 3,
   NumeratorNegative = 4,
@@ -16,7 +15,8 @@ const enum ValidationFailTypes {
   SDNegative = 9,
   NumeratorNaN = 10,
   DenominatorNaN = 11,
-  SDNaN = 12
+  SDNaN = 12,
+  DenominatorZero = 13
 }
 
 function validateInputDataImpl(key: string,
@@ -30,50 +30,39 @@ function validateInputDataImpl(key: string,
   if (isNullOrUndefined(key)) {
     rtn.message = "Date missing";
     rtn.type = ValidationFailTypes.DateMissing;
-  }
-
-  if (isNullOrUndefined(numerator)) {
+  } else if (isNullOrUndefined(numerator)) {
     rtn.message = "Numerator missing";
     rtn.type = ValidationFailTypes.NumeratorMissing;
-  }
-
-  if (isNaN(numerator)) {
+  } else if (!isFinite(numerator)) {
     rtn.message = "Numerator is not a number";
     rtn.type = ValidationFailTypes.NumeratorNaN;
-  }
-
-  if (chart_type_props.numerator_non_negative && numerator < 0) {
+  } else if (chart_type_props.numerator_non_negative && numerator < 0) {
     rtn.message = "Numerator negative";
     rtn.type = ValidationFailTypes.NumeratorNegative;
-  }
-
-  if (check_denom) {
-    if (isNullOrUndefined(denominator)) {
-      rtn.message = "Denominator missing";
-      rtn.type = ValidationFailTypes.DenominatorMissing;
-    } else if (isNaN(denominator)) {
-      rtn.message = "Denominator is not a number";
-      rtn.type = ValidationFailTypes.DenominatorNaN;
-    } else if (denominator < 0) {
-      rtn.message = "Denominator negative";
-      rtn.type = ValidationFailTypes.DenominatorNegative;
-    } else if (chart_type_props.numerator_leq_denominator && denominator < numerator) {
-      rtn.message = "Denominator < numerator";
-      rtn.type = ValidationFailTypes.DenominatorLessThanNumerator;
-    }
-  }
-
-  if (chart_type_props.needs_sd) {
-    if (isNullOrUndefined(xbar_sd)) {
-      rtn.message = "SD missing";
-      rtn.type = ValidationFailTypes.SDMissing;
-    } else if (isNaN(xbar_sd)) {
-      rtn.message = "SD is not a number";
-      rtn.type = ValidationFailTypes.SDNaN;
-    } else if (xbar_sd < 0) {
-      rtn.message = "SD negative";
-      rtn.type = ValidationFailTypes.SDNegative;
-    }
+  } else if (check_denom && isNullOrUndefined(denominator)) {
+    rtn.message = "Denominator missing";
+    rtn.type = ValidationFailTypes.DenominatorMissing;
+  } else if (check_denom && !isFinite(denominator)) {
+    rtn.message = "Denominator is not a number";
+    rtn.type = ValidationFailTypes.DenominatorNaN;
+  } else if (check_denom && denominator < 0) {
+    rtn.message = "Denominator negative";
+    rtn.type = ValidationFailTypes.DenominatorNegative;
+  } else if (check_denom && denominator === 0) {
+    rtn.message = "Denominator is zero";
+    rtn.type = ValidationFailTypes.DenominatorZero;
+  } else if (check_denom && chart_type_props.numerator_leq_denominator && denominator < numerator) {
+    rtn.message = "Denominator < numerator";
+    rtn.type = ValidationFailTypes.DenominatorLessThanNumerator;
+  } else if (chart_type_props.needs_sd && isNullOrUndefined(xbar_sd)) {
+    rtn.message = "SD missing";
+    rtn.type = ValidationFailTypes.SDMissing;
+  } else if (chart_type_props.needs_sd && !isFinite(xbar_sd)) {
+    rtn.message = "SD is not a number";
+    rtn.type = ValidationFailTypes.SDNaN;
+  } else if (chart_type_props.needs_sd && xbar_sd < 0) {
+    rtn.message = "SD negative";
+    rtn.type = ValidationFailTypes.SDNegative;
   }
   return rtn;
 }
@@ -93,7 +82,8 @@ export default function validateInputData(keys: string[],
                       || (chart_type_props.denominator_optional && !isNullOrUndefined(denominators) && denominators.length > 0);
   const n: number = idxs.length;
   for (let i = 0; i < n; i++) {
-    const validation = validateInputDataImpl(keys[i], numerators?.[i], denominators?.[i], xbar_sds?.[i], chart_type_props,  check_denom);
+    const idx = idxs[i];
+    const validation = validateInputDataImpl(keys[idx], numerators?.[idx], denominators?.[idx], xbar_sds?.[idx], chart_type_props,  check_denom);
     messages.push(validation.message);
     all_status.push(validation.type);
   }
@@ -119,10 +109,6 @@ export default function validateInputData(keys: string[],
 
   if (allSameType && commonType !== ValidationFailTypes.Valid) {
     switch(commonType) {
-      case ValidationFailTypes.GroupingMissing: {
-        validationRtn.error = "Grouping missing"
-        break;
-      }
       case ValidationFailTypes.DateMissing: {
         validationRtn.error = "All dates/IDs are missing or null!"
         break;
@@ -149,6 +135,10 @@ export default function validateInputData(keys: string[],
       }
       case ValidationFailTypes.DenominatorNegative: {
         validationRtn.error = "All denominators are negative!"
+        break;
+      }
+      case ValidationFailTypes.DenominatorZero: {
+        validationRtn.error = "All denominators are zero!";
         break;
       }
       case ValidationFailTypes.DenominatorLessThanNumerator: {


### PR DESCRIPTION
## Summary
- **validateInputData**: Fix DenominatorZero enum, replace isNaN with !isFinite, refactor to flat if-else chain preventing inter-section overwrite (BUG 8), add idxs parameter, remove dead GroupingMissing enum
- **validateDataView**: Fix key-role check (was always false), fix variable-split bug (error message named wrong chart type)
- **derivedSettingsClass**: Remove u/up from `numerator_leq_denominator` — u-charts are rate charts where numerator can legitimately exceed denominator (BUG 9)
- **Rendering layer**: Add null guards for lineData/plotData arrays in viewModelClass, drawLines, drawLineLabels

## Impact
- BUG 9 (u-chart constraint) is the highest-impact fix: currently rejects valid u-chart data where defect count > unit count
- BUG 8 (inter-section overwrite) masks real validation errors by letting later checks overwrite earlier ones
- Rendering null-safety prevents potential runtime crashes on charts without all limit lines

## Test plan
- [x] All 216 existing tests pass on this branch
- [x] Manual verification: u-chart with numerator > denominator no longer rejected
- [x] Manual verification: validation errors report correct field (first match wins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)